### PR TITLE
Get banks and create subaccount

### DIFF
--- a/chapa/api.py
+++ b/chapa/api.py
@@ -169,7 +169,7 @@ class Chapa:
             headers=headers
         )
         return response
-    
+
     def get_banks(self, headers=None):
         """Get the list of all banks
         Response:
@@ -200,7 +200,8 @@ class Chapa:
             account_name (str): The vendor/merchant account`s name matches from the bank account
             bank_code (str): The bank id (you can get this from the get_banks method)
             account_number (str): The bank account number for this subaccount
-            split_type (str): The type of split you want to use with this subaccount (percentage or flat)
+            split_type (str): The type of split you want to use with this subaccount
+                              (percentage or flat)
             split_value (float): The amount you want to get as commission on each transaction
 
         Response:

--- a/chapa/api.py
+++ b/chapa/api.py
@@ -169,3 +169,56 @@ class Chapa:
             headers=headers
         )
         return response
+    
+    def get_banks(self, headers=None):
+        """Get the list of all banks
+        Response:
+            dict: response from the server
+            response(Response): response object of the response data return from the Chapa server.
+        """
+        response = self._construct_request(
+            url=f"{self.base_url}/{self.api_version}/banks",
+            method="get",
+            headers=headers,
+        )
+        return response
+
+    def create_subaccount(
+        self,
+        business_name: str,
+        account_name: str,
+        bank_code: str,
+        account_number: str,
+        split_type: str,
+        split_value: float,
+        headers=None,
+    ):
+        """Create a subaccount
+
+        Args:
+            business_name (str): The vendor/merchant detail the subaccount for
+            account_name (str): The vendor/merchant account`s name matches from the bank account
+            bank_code (str): The bank id (you can get this from the get_banks method)
+            account_number (str): The bank account number for this subaccount
+            split_type (str): The type of split you want to use with this subaccount (percentage or flat)
+            split_value (float): The amount you want to get as commission on each transaction
+
+        Response:
+            dict: response from the server
+            response(Response): response object of the response data return from the Chapa server.
+        """
+        data = {
+            "business_name": business_name,
+            "account_name": account_name,
+            "bank_code": bank_code,
+            "account_number": account_number,
+            "split_value": split_value,
+            "split_type": split_type,
+        }
+        response = self._construct_request(
+            url=f"{self.base_url}/{self.api_version}/subaccount",
+            method="post",
+            data=data,
+            headers=headers,
+        )
+        return response


### PR DESCRIPTION
## Feature

Title: A method to get banks info and create a subaccount

## Description

The change includes two methods, where one is a method that utilizes the get_banks endpoint to fetch all the information about banks that Chapa supports and the other one is a method that uses Create Subaccount API available on the Chapa server to create a subaccount.

## Type of change

- [ feat ] get_banks
- [ feat ] create_subaccount