### PR TITLE
fix import issue from pypi

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -31,7 +31,9 @@ jobs:
         python -m pip install build
         python -m pip install wheel twine setuptools
     - name: Build a binary wheel and a source tarball
-      run: python -m build
+      run: |
+        rm -rf dist/
+        python -m build
 
     - name: Publish distribution 📦 to PyPI
       run: python -m twine upload dist/* --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
 
-version_number = os.environ.get('CHAPA_VERSION', '0.1.0')
+version_number = os.environ.get('CHAPA_VERSION', '0.1.2')
 
 setuptools.setup(
     name='chapa',


### PR DESCRIPTION
## Issue

Title: Import issue on recent version 

## Description

in the recent version you can't import chapa class from thee package due to wrong version published.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Update Documentation(Updating Readme or any other Typos)
